### PR TITLE
V0.9.2 fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Working on a new module for capturing data sets and their metadata. This module will allow the registration of various data sources (such as AWS S3), and the creation of data set records that will include one-or-more resources from these storage locations, along with metadata describing them. Users will then be allowed to associate one-or-more data sets with a study. Studies will likely get data set records created for them, which will include their storage folder and notebook by default.
 - Will add a notifications feature that will capture and display notifications for users.
 
+## [0.9.2] - 2023-06-XX
+
+### Fixed
+- Fixed a bug causing multiple requests to be sent to GitLab servers when creating a new study.
+- Fixed a circular bean dependencies in back-end.
+- Disabled reactive ElasticSearch autoconfiguration, which could cause issue on application startup.
+- Removed new-folder and file-upload controls from File Manager for read-only folders.
+
 ## [0.9.1] - 2023-06-20
 
 ### Added

--- a/client/package.json
+++ b/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "study-tracker-client",
-  "version": "0.9.1",
+  "version": "0.9.2",
   "description": "React front-end client for Study Tracker",
   "private": true,
   "author": "Will Oemler <will@oemler.io>",

--- a/client/pom.xml
+++ b/client/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>io.studytracker</groupId>
     <artifactId>study-tracker-parent</artifactId>
-    <version>0.9.1</version>
+    <version>0.9.2</version>
   </parent>
 
   <artifactId>study-tracker-client</artifactId>

--- a/client/src/common/fileManager/FileManagerContent.js
+++ b/client/src/common/fileManager/FileManagerContent.js
@@ -209,24 +209,36 @@ const FileManagerContent = ({
 
             <div className="card-toolbar">
 
-              <Button
-                  variant="outline-primary"
-                  className="me-2"
-                  onClick={() => setNewFolderModalIsOpen(true)}
-              >
-                <FolderPlus size={18} />
-                &nbsp;&nbsp;
-                New Folder
-              </Button>
+              {
+                rootFolder.writeEnabled ? (
+                  <>
+                    <Button
+                      variant="outline-primary"
+                      className="me-2"
+                      onClick={() => setNewFolderModalIsOpen(true)}
+                    >
+                      <FolderPlus size={18} />
+                      &nbsp;&nbsp;
+                      New Folder
+                    </Button>
 
-              <Button
-                  variant="primary"
-                  onClick={() => setUploadModalIsOpen(true)}
-              >
-                <Upload size={18} />
-                &nbsp;&nbsp;
-                Upload
-              </Button>
+                    <Button
+                      variant="primary"
+                      onClick={() => setUploadModalIsOpen(true)}
+                    >
+                      <Upload size={18} />
+                      &nbsp;&nbsp;
+                      Upload
+                    </Button>
+                  </>
+                ) : (
+                  <Button variant={"outline-secondary"} disabled={true}>
+                    Read Only
+                  </Button>
+                )
+              }
+
+
 
             </div>
 

--- a/client/src/common/forms/GitInputsCard.js
+++ b/client/src/common/forms/GitInputsCard.js
@@ -38,7 +38,7 @@ const GitInputsCard = ({
         setEnabled(false);
       }
     })
-  });
+  }, []);
 
   console.debug("Program: ", selectedProgram);
 

--- a/pom.xml
+++ b/pom.xml
@@ -15,7 +15,7 @@
 
   <groupId>io.studytracker</groupId>
   <artifactId>study-tracker-parent</artifactId>
-  <version>0.9.1</version>
+  <version>0.9.2</version>
   <name>Study Tracker Parent</name>
   <packaging>pom</packaging>
 

--- a/web/pom.xml
+++ b/web/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>io.studytracker</groupId>
 		<artifactId>study-tracker-parent</artifactId>
-		<version>0.9.1</version>
+		<version>0.9.2</version>
 	</parent>
 
 	<artifactId>study-tracker-web</artifactId>

--- a/web/src/main/java/io/studytracker/Application.java
+++ b/web/src/main/java/io/studytracker/Application.java
@@ -18,6 +18,7 @@ package io.studytracker;
 
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.autoconfigure.data.elasticsearch.ElasticsearchRepositoriesAutoConfiguration;
+import org.springframework.boot.autoconfigure.data.elasticsearch.ReactiveElasticsearchRepositoriesAutoConfiguration;
 import org.springframework.boot.autoconfigure.elasticsearch.ElasticsearchRestClientAutoConfiguration;
 import org.springframework.boot.autoconfigure.mail.MailSenderAutoConfiguration;
 import org.springframework.boot.autoconfigure.security.servlet.UserDetailsServiceAutoConfiguration;
@@ -32,6 +33,7 @@ import org.springframework.context.annotation.PropertySource;
 				UserDetailsServiceAutoConfiguration.class,
 				ElasticsearchRepositoriesAutoConfiguration.class,
 				ElasticsearchRestClientAutoConfiguration.class,
+				ReactiveElasticsearchRepositoriesAutoConfiguration.class,
 				MailSenderAutoConfiguration.class
 		}
 	)

--- a/web/src/main/java/io/studytracker/service/NamingService.java
+++ b/web/src/main/java/io/studytracker/service/NamingService.java
@@ -23,6 +23,7 @@ import io.studytracker.model.Collaborator;
 import io.studytracker.model.Program;
 import io.studytracker.model.Study;
 import io.studytracker.repository.AssayRepository;
+import io.studytracker.repository.ProgramRepository;
 import io.studytracker.repository.StudyRepository;
 import org.springframework.beans.factory.annotation.Autowired;
 
@@ -33,7 +34,7 @@ public class NamingService {
   private StudyProperties studyProperties;
 
   @Autowired
-  private ProgramService programService;
+  private ProgramRepository programRepository;
 
   @Autowired
   private StudyRepository studyRepository;
@@ -53,7 +54,7 @@ public class NamingService {
     }
     Program program = study.getProgram();
     Integer count = studyProperties.getStudyCodeCounterStart();
-    for (Program p : programService.findByCode(program.getCode())) {
+    for (Program p : programRepository.findByCode(program.getCode())) {
       count = count + (studyRepository.findActiveProgramStudies(p.getId())).size();
     }
     return program.getCode()

--- a/web/src/main/java/io/studytracker/storage/StudyStorageServiceLookup.java
+++ b/web/src/main/java/io/studytracker/storage/StudyStorageServiceLookup.java
@@ -28,6 +28,7 @@ import java.util.Optional;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.ApplicationContext;
 import org.springframework.stereotype.Component;
 
 /**
@@ -43,20 +44,11 @@ public class StudyStorageServiceLookup {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(StudyStorageServiceLookup.class);
 
-  @Autowired(required = false)
-  private EgnyteStudyStorageService egnyteStudyStorageService;
-
-  @Autowired(required = false)
-  private S3StudyStorageService s3StudyStorageService;
-
-  @Autowired(required = false)
-  private LocalFileSystemStorageService localFileSystemStorageService;
-
-  @Autowired(required = false)
-  private OneDriveStorageService oneDriveStorageService;
-
   @Autowired
   private StorageDriveRepository storageDriveRepository;
+
+  @Autowired
+  private ApplicationContext context;
 
   public Optional<StudyStorageService> lookup(StorageDriveFolder folder) {
     LOGGER.debug("Looking up StudyStorageService for storageDriveFolder: {}", folder);
@@ -70,13 +62,13 @@ public class StudyStorageServiceLookup {
     LOGGER.debug("Looking up StudyStorageService for storageLocationType: {}", driveType);
     switch (driveType) {
       case EGNYTE:
-        return Optional.ofNullable(egnyteStudyStorageService);
+        return Optional.of(context.getBean(EgnyteStudyStorageService.class));
       case S3:
-        return Optional.ofNullable(s3StudyStorageService);
+        return Optional.of(context.getBean(S3StudyStorageService.class));
       case LOCAL:
-        return Optional.ofNullable(localFileSystemStorageService);
+        return Optional.of(context.getBean(LocalFileSystemStorageService.class));
       case ONEDRIVE:
-        return Optional.ofNullable(oneDriveStorageService);
+        return Optional.of(context.getBean(OneDriveStorageService.class));
       default:
         return Optional.empty();
     }


### PR DESCRIPTION
### Fixed
- Fixed a bug causing multiple requests to be sent to GitLab servers when creating a new study.
- Fixed a circular bean dependencies in back-end.
- Disabled reactive ElasticSearch autoconfiguration, which could cause issue on application startup.
- Removed new-folder and file-upload controls from File Manager for read-only folders.