### PR TITLE
Fix Egnyte subfolder path check

### DIFF
--- a/web/src/main/java/io/studytracker/egnyte/EgnyteUtils.java
+++ b/web/src/main/java/io/studytracker/egnyte/EgnyteUtils.java
@@ -197,7 +197,7 @@ public class EgnyteUtils {
     if (childPath.endsWith("/")) {
       childPath = childPath.substring(0, childPath.length() - 1);
     }
-    return childPath.startsWith(parentPath);
+    return childPath.startsWith(parentPath + "/");
   }
 
   public static String cleanInputObjectName(String input) {

--- a/web/src/test/java/io/studytracker/test/egnyte/EgnyteUtilsTests.java
+++ b/web/src/test/java/io/studytracker/test/egnyte/EgnyteUtilsTests.java
@@ -1,0 +1,17 @@
+package io.studytracker.test.egnyte;
+
+import io.studytracker.egnyte.EgnyteUtils;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class EgnyteUtilsTests {
+
+  @Test
+  public void testDirectoryIsSubfolderOf() {
+    Assert.assertTrue(EgnyteUtils.directoryIsSubfolderOf("/a/b", "/a/b"));
+    Assert.assertTrue(EgnyteUtils.directoryIsSubfolderOf("/a/b", "/a/b/c"));
+    Assert.assertTrue(EgnyteUtils.directoryIsSubfolderOf("/a/b/", "/a/b/c/"));
+    Assert.assertFalse(EgnyteUtils.directoryIsSubfolderOf("/a/b", "/a/bc"));
+    Assert.assertFalse(EgnyteUtils.directoryIsSubfolderOf("/a/b", "/a/bc/d"));
+  }
+}


### PR DESCRIPTION
## Summary
- fix `EgnyteUtils.directoryIsSubfolderOf` to ensure correct prefix matching
- add unit test for the new behavior

## Testing
- `./mvnw -q -pl web test` *(fails: Failed to fetch https://repo.maven.apache.org/...)*

------
https://chatgpt.com/codex/tasks/task_e_684305794b44833397297f9684a5d344