### PR TITLE
Hotfix/v1.0.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.2] - 2025-07-11
+
+### Changed
+- Git repository descriptions will now only use the first sentence of a study or assay description (#219).
+
+### Fixed
+- Fixed the export of some data types.
+- Git repository names will no longer drop hyphens from the text.
+
 ## [1.0.1] - 2025-06-10
 
 ### Added

--- a/client/package.json
+++ b/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "study-tracker-client",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "React front-end client for Study Tracker",
   "private": true,
   "author": "Will Oemler <will@oemler.io>",

--- a/client/pom.xml
+++ b/client/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>io.studytracker</groupId>
     <artifactId>study-tracker-parent</artifactId>
-    <version>1.0.1</version>
+    <version>1.0.2</version>
   </parent>
 
   <artifactId>study-tracker-client</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -15,7 +15,7 @@
 
   <groupId>io.studytracker</groupId>
   <artifactId>study-tracker-parent</artifactId>
-  <version>1.0.1</version>
+  <version>1.0.2</version>
   <name>Study Tracker Parent</name>
   <packaging>pom</packaging>
 

--- a/web/pom.xml
+++ b/web/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>io.studytracker</groupId>
 		<artifactId>study-tracker-parent</artifactId>
-		<version>1.0.1</version>
+		<version>1.0.2</version>
 	</parent>
 
 	<artifactId>study-tracker-web</artifactId>

--- a/web/src/main/java/io/studytracker/export/DataExportService.java
+++ b/web/src/main/java/io/studytracker/export/DataExportService.java
@@ -495,6 +495,7 @@ public class DataExportService {
       // Write header
       String[] header = {
           "ID",
+          "GitRepositoryId",
           "GitLabGroupId",
           "RepositoryId",
           "Name",
@@ -506,6 +507,7 @@ public class DataExportService {
       for (GitLabRepository repository : gitLabRepositoryRepository.findAll()) {
         String[] row = {
             String.valueOf(repository.getId()),
+            String.valueOf(repository.getGitRepository().getId()),
             String.valueOf(repository.getGitLabGroup().getId()),
             String.valueOf(repository.getRepositoryId()),
             repository.getName(),
@@ -909,8 +911,8 @@ public class DataExportService {
             assay.getName(),
             assay.getDescription(),
             assay.getStatus().toString(),
-            assay.getCreatedBy().toString(),
-            assay.getLastModifiedBy() != null ? assay.getLastModifiedBy().getDisplayName() : "",
+            String.valueOf(assay.getCreatedBy().getId()),
+            assay.getLastModifiedBy() != null ? String.valueOf(assay.getLastModifiedBy().getId()) : "",
             assay.getOwner().getId().toString(),
             SDF.format(assay.getCreatedAt()),
             assay.getUpdatedAt() != null ? SDF.format(assay.getUpdatedAt()) : "",
@@ -1022,7 +1024,7 @@ public class DataExportService {
             task.getLastModifiedBy() != null ? String.valueOf(task.getLastModifiedBy().getId()) : "",
             task.getAssignedTo() != null ? String.valueOf(task.getAssignedTo().getId()) : "",
             task.getDueDate() != null ? SDF.format(task.getDueDate()) : "",
-            objectMapper.writeValueAsString(task.getData())
+            task.getData() != null ? objectMapper.writeValueAsString(task.getData()) : "{}"
         };
         writer.writeNext(row);
       }

--- a/web/src/main/java/io/studytracker/gitlab/GitLabUtils.java
+++ b/web/src/main/java/io/studytracker/gitlab/GitLabUtils.java
@@ -25,10 +25,11 @@ import io.studytracker.gitlab.entities.GitLabUser;
 import io.studytracker.model.Assay;
 import io.studytracker.model.Program;
 import io.studytracker.model.Study;
-import java.text.BreakIterator;
-import java.util.Locale;
 import org.springframework.lang.NonNull;
 import org.springframework.lang.Nullable;
+
+import java.text.BreakIterator;
+import java.util.Locale;
 
 public class GitLabUtils {
 
@@ -52,11 +53,11 @@ public class GitLabUtils {
   }
 
   public static String getProgramGroupName(Program program) {
-    return program.getName().replaceAll("[^\\w\\d\\s_+.]", "");
+    return program.getName().replaceAll("[^\\w\\d\\s_+.-]", "");
   }
 
   public static String getStudyProjectName(Study study) {
-    return study.getCode() + " - " + study.getName().replaceAll("[^\\w\\d\\s_+.]", "");
+    return study.getCode() + " - " + study.getName().replaceAll("[^\\w\\d\\s_+.-]", "");
   }
 
   public static String getStudyProjectPath(Study study) {
@@ -64,7 +65,7 @@ public class GitLabUtils {
   }
 
   public static String getAssayProjectName(Assay assay) {
-    return assay.getCode() + " - " + assay.getName().replaceAll("[^\\w\\d\\s_+.]", "");
+    return assay.getCode() + " - " + assay.getName().replaceAll("[^\\w\\d\\s_+.-]", "");
   }
 
   public static String getAssayProjectPath(Assay assay) {
@@ -111,7 +112,7 @@ public class GitLabUtils {
 
   public static String trimRepositoryDescription(String description) {
     BreakIterator iterator = BreakIterator.getSentenceInstance(Locale.US);
-    String cleaned = description.replaceAll("<[^>]*>", "");
+    String cleaned = description.replaceAll("<[^>]*>", "").replaceAll("\\..+", ".");
     iterator.setText(cleaned);
     int start = iterator.first();
     int end = iterator.next();

--- a/web/src/test/java/io/studytracker/test/gitlab/GitLabServiceTests.java
+++ b/web/src/test/java/io/studytracker/test/gitlab/GitLabServiceTests.java
@@ -173,12 +173,14 @@ public class GitLabServiceTests {
 
     Study study = new Study();
     study.setName("Example Study: In-vitro experiment");
+    study.setCode("TST-123");
+
     String projectName = GitLabUtils.getStudyProjectName(study);
     String projectPath = GitLabUtils.getStudyProjectPath(study);
     System.out.println(projectName);
     System.out.println(projectPath);
-    Assert.assertEquals("Example Study In-vitro experiment", projectName);
-    Assert.assertEquals("example-study-in-vitro-experiment", projectPath);
+    Assert.assertEquals("TST-123 - Example Study In-vitro experiment", projectName);
+    Assert.assertEquals("tst-123-example-study-in-vitro-experiment", projectPath);
     Assert.assertTrue(projectName.length() < 255);
     Assert.assertTrue(projectPath.length() < 255);
 

--- a/web/src/test/java/io/studytracker/test/gitlab/GitLabServiceTests.java
+++ b/web/src/test/java/io/studytracker/test/gitlab/GitLabServiceTests.java
@@ -22,20 +22,8 @@ import io.studytracker.exception.RecordNotFoundException;
 import io.studytracker.gitlab.GitLabIntegrationService;
 import io.studytracker.gitlab.GitLabService;
 import io.studytracker.gitlab.GitLabUtils;
-import io.studytracker.model.GitGroup;
-import io.studytracker.model.GitLabGroup;
-import io.studytracker.model.GitLabIntegration;
-import io.studytracker.model.GitLabRepository;
-import io.studytracker.model.GitRepository;
-import io.studytracker.model.GitServiceType;
-import io.studytracker.model.Program;
-import io.studytracker.model.Study;
-import io.studytracker.repository.AssayRepository;
-import io.studytracker.repository.GitLabGroupRepository;
-import io.studytracker.repository.GitLabRepositoryRepository;
-import io.studytracker.repository.ProgramRepository;
-import io.studytracker.repository.StudyRepository;
-import java.util.List;
+import io.studytracker.model.*;
+import io.studytracker.repository.*;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -46,6 +34,8 @@ import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.web.client.HttpClientErrorException;
+
+import java.util.List;
 
 @RunWith(SpringRunner.class)
 @SpringBootTest(classes = Application.class, webEnvironment = WebEnvironment.RANDOM_PORT)
@@ -175,18 +165,20 @@ public class GitLabServiceTests {
   @Test
   public void repositoryNamingTest() {
 
-    String description = "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.";
+    String description = "<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>";
     String trimmed = GitLabUtils.trimRepositoryDescription(description);
     System.out.println(trimmed);
     Assert.assertTrue(trimmed.length() < 255);
+    Assert.assertEquals("Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.", trimmed);
 
-    Program program = programRepository.findByName(EXAMPLE_PROGRAM)
-        .orElseThrow(RecordNotFoundException::new);
-    Study study = studyRepository.findByProgramId(program.getId()).get(0);
+    Study study = new Study();
+    study.setName("Example Study: In-vitro experiment");
     String projectName = GitLabUtils.getStudyProjectName(study);
     String projectPath = GitLabUtils.getStudyProjectPath(study);
     System.out.println(projectName);
     System.out.println(projectPath);
+    Assert.assertEquals("Example Study In-vitro experiment", projectName);
+    Assert.assertEquals("example-study-in-vitro-experiment", projectPath);
     Assert.assertTrue(projectName.length() < 255);
     Assert.assertTrue(projectPath.length() < 255);
 


### PR DESCRIPTION
### Changed
- Git repository descriptions will now only use the first sentence of a study or assay description (#219).

### Fixed
- Fixed the export of some data types.
- Git repository names will no longer drop hyphens from the text.